### PR TITLE
Fix Docker build failure by adding DATABASE_URL for build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ RUN corepack enable && corepack prepare pnpm@9.10.0 --activate
 # Set environment variables for build
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=1
+# Dummy DATABASE_URL for build time (real URL provided at runtime)
+ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 
 # Generate Prisma Client
 RUN cd apps/web && pnpm prisma generate


### PR DESCRIPTION
## Summary

This PR fixes the Docker build failure caused by a missing `DATABASE_URL` environment variable during the build stage.

### Problem

The build was failing with:
```
Error [PrismaClientConstructorValidationError]: Invalid value undefined for datasource "db" provided to PrismaClient constructor.
It should have this form: { url: "CONNECTION_STRING" }
```

**Root Cause:**
1. During `pnpm build`, Next.js attempts to pre-render pages and collect page data
2. The `/api/auth/signup` route imports code that instantiates PrismaClient (`apps/web/src/server/db.ts:11`)
3. PrismaClient constructor requires `DATABASE_URL` to be defined, even at build time
4. The Dockerfile builder stage did not provide this environment variable
5. Even though `SKIP_ENV_VALIDATION=1` was set, it only skips validation in `env.js` but doesn't prevent PrismaClient from requiring the URL

### Solution

Added a dummy `DATABASE_URL` environment variable to the Dockerfile's builder stage:

```dockerfile
ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
```

**Why this works:**
- PrismaClient needs the URL to be defined when instantiated during build
- No actual database connection is made during the build process
- The real `DATABASE_URL` is provided at runtime via `docker-compose.yml` (already correctly configured)
- This is a standard pattern for Next.js apps using Prisma in Docker

### Changes

- `Dockerfile:58-59` - Added dummy DATABASE_URL for build time with explanatory comment

## Test Plan

- [ ] Build the Docker image and verify it completes successfully
- [ ] Verify the application starts correctly with the real DATABASE_URL from docker-compose
- [ ] Confirm database connections work at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)