### PR TITLE
Fix Docker build failure in apps/web/Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -59,6 +59,8 @@ RUN corepack enable && corepack prepare pnpm@9.10.0 --activate
 # Set environment variables for build
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV SKIP_ENV_VALIDATION=1
+# Dummy DATABASE_URL for build time (real URL provided at runtime)
+ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 
 # Generate Prisma Client
 RUN cd apps/web && pnpm prisma generate


### PR DESCRIPTION
## Summary

This PR fixes the Docker build failure by adding the missing `DATABASE_URL` environment variable to `apps/web/Dockerfile` - the **actual Dockerfile used by docker-compose.yml and Dokploy**.

### Context

PR #57 fixed the root `/Dockerfile`, but `docker-compose.yml:80` specifies:
```yaml
dockerfile: apps/web/Dockerfile
```

So deployments were still failing because `apps/web/Dockerfile` was missing the fix.

### Problem

The build fails with:
```
Error [PrismaClientConstructorValidationError]: Invalid value undefined for datasource "db" provided to PrismaClient constructor.
Failed to collect page data for /api/trpc/[trpc]
```

**Root Cause:**
- During `pnpm build`, Next.js pre-renders pages including `/api/trpc/[trpc]`
- This route imports `~/server/api/trpc` which imports `~/server/db` 
- The db module instantiates PrismaClient with `env.DATABASE_URL`
- PrismaClient constructor requires `DATABASE_URL` to be defined at build time
- `apps/web/Dockerfile` didn't provide this variable

### Solution

Added the same fix that was applied to the root Dockerfile:

```dockerfile
# Dummy DATABASE_URL for build time (real URL provided at runtime)
ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
```

**Why this works:**
- PrismaClient needs the URL defined during instantiation
- No actual database connection occurs during build
- The real `DATABASE_URL` is provided at runtime via docker-compose.yml

### Changes

- `apps/web/Dockerfile:62-63` - Added dummy DATABASE_URL for build time

### Impact

This fixes:
- ✅ Docker Compose builds (`docker compose up`)
- ✅ Dokploy deployments
- ✅ Any deployment using `apps/web/Dockerfile`

## Test Plan

- [x] Verify the fix is in the correct Dockerfile (apps/web/Dockerfile)
- [ ] Build Docker image locally and confirm it succeeds
- [ ] Deploy to Dokploy and verify successful build
- [ ] Confirm runtime database connections work with real DATABASE_URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)