### PR TITLE
Fix: Use correct Docker build stage for seed service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
+      target: deps
     environment:
       - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/meal-planner-demo?connection_limit=10&pool_timeout=30&connect_timeout=30
       - SKIP_ENV_VALIDATION=1


### PR DESCRIPTION
## Summary
Fixes the seed service failure caused by missing pnpm in the Docker container.

## Problem
The seed service was failing during Dokploy deployment with:
```
Error: Cannot find module '/app/apps/web/pnpm'
```

**Root Cause:** The seed service was building from the default `runner` stage, which is a minimal production image that does NOT include pnpm. When the seed service tried to execute `pnpm db:seed`, pnpm was not available.

## Solution
Add `target: deps` to the seed service build configuration in docker-compose.yml. This ensures the seed service builds from the `deps` stage which:
- Includes pnpm and the package manager tools
- Has all node_modules installed
- Allows `pnpm db:seed` to execute successfully

## Files Changed
- `docker-compose.yml` - Added `target: deps` to seed service build configuration (line 23)

## Comparison
The migrate service already uses this pattern correctly:
```yaml
migrate:
  build:
    target: deps  # ✓ Has pnpm available
```

The seed service now matches this pattern.

## Impact
- Seed service will have all required dependencies
- Database seeding will execute successfully during deployment
- Fixes the "Error: Cannot find module '/app/apps/web/pnpm'" error

Relates to #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)