### PR TITLE
Improve mobile plan experience

### DIFF
--- a/apps/web/src/app/_components/MealPlanWizard.tsx
+++ b/apps/web/src/app/_components/MealPlanWizard.tsx
@@ -97,7 +97,7 @@ export default function MealPlanWizard({
                 id="householdSize"
                 value={householdSize}
                 onChange={(e) => setHouseholdSize(Number(e.target.value))}
-                className="mt-2 block w-full rounded-xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-2 block w-full rounded-2xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 sm:rounded-xl min-h-[56px]"
               >
                 {[1, 2, 3, 4, 5, 6].map((num) => (
                   <option key={num} value={num}>
@@ -116,7 +116,7 @@ export default function MealPlanWizard({
                 id="mealsPerDay"
                 value={mealsPerDay}
                 onChange={(e) => setMealsPerDay(Number(e.target.value))}
-                className="mt-2 block w-full rounded-xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-2 block w-full rounded-2xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 sm:rounded-xl min-h-[56px]"
               >
                 <option value={1}>1 meal (Dinner only)</option>
                 <option value={2}>2 meals (Lunch & Dinner)</option>
@@ -133,7 +133,7 @@ export default function MealPlanWizard({
                 id="days"
                 value={days}
                 onChange={(e) => setDays(Number(e.target.value))}
-                className="mt-2 block w-full rounded-xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-2 block w-full rounded-2xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 sm:rounded-xl min-h-[56px]"
               >
                 {[3, 4, 5, 6, 7].map((num) => {
                   const isPremiumOption = !isPremium && num > 3;
@@ -156,27 +156,27 @@ export default function MealPlanWizard({
               <span className="block text-sm font-semibold text-gray-900">Dietary preferences</span>
               <label
                 htmlFor="isVegetarian"
-                className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-base text-gray-700 shadow-sm transition hover:border-emerald-400 focus-within:border-emerald-500"
+                className="flex min-h-[60px] items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 text-base text-gray-700 shadow-sm transition hover:border-emerald-400 focus-within:border-emerald-500 sm:rounded-xl"
               >
                 <input
                   type="checkbox"
                   id="isVegetarian"
                   checked={isVegetarian}
                   onChange={(e) => setIsVegetarian(e.target.checked)}
-                  className="h-5 w-5 shrink-0 rounded-md border-2 border-gray-300 text-emerald-600 focus:ring-2 focus:ring-emerald-600 sm:h-4 sm:w-4"
+                  className="h-6 w-6 shrink-0 rounded-md border-2 border-gray-300 text-emerald-600 focus:ring-2 focus:ring-emerald-600"
                 />
                 <span>Vegetarian</span>
               </label>
               <label
                 htmlFor="isDairyFree"
-                className="flex items-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-base text-gray-700 shadow-sm transition hover:border-emerald-400 focus-within:border-emerald-500"
+                className="flex min-h-[60px] items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 text-base text-gray-700 shadow-sm transition hover:border-emerald-400 focus-within:border-emerald-500 sm:rounded-xl"
               >
                 <input
                   type="checkbox"
                   id="isDairyFree"
                   checked={isDairyFree}
                   onChange={(e) => setIsDairyFree(e.target.checked)}
-                  className="h-5 w-5 shrink-0 rounded-md border-2 border-gray-300 text-emerald-600 focus:ring-2 focus:ring-emerald-600 sm:h-4 sm:w-4"
+                  className="h-6 w-6 shrink-0 rounded-md border-2 border-gray-300 text-emerald-600 focus:ring-2 focus:ring-emerald-600"
                 />
                 <span>Dairy-free</span>
               </label>
@@ -193,7 +193,7 @@ export default function MealPlanWizard({
                 value={dislikes}
                 onChange={(e) => setDislikes(e.target.value)}
                 placeholder="e.g., mushrooms, olives"
-                className="mt-2 block w-full rounded-xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-2 block w-full rounded-2xl border border-gray-200 bg-white px-4 py-3.5 text-base text-gray-900 shadow-sm transition focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 sm:rounded-xl min-h-[56px]"
               />
               <p className="mt-1 text-xs text-gray-500">Separate multiple items with commas</p>
             </div>

--- a/apps/web/src/app/_components/RecipeCard.tsx
+++ b/apps/web/src/app/_components/RecipeCard.tsx
@@ -66,7 +66,7 @@ export default function RecipeCard({ item, onOpenDetail }: RecipeCardProps) {
   return (
     <button
       type="button"
-      className="group relative w-full cursor-pointer overflow-hidden rounded-xl bg-white text-left shadow-md ring-1 ring-gray-200 transition-all duration-300 hover:shadow-xl hover:ring-2 hover:ring-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500"
+      className="group relative w-full cursor-pointer overflow-hidden rounded-2xl bg-white text-left shadow-md ring-1 ring-gray-200 transition-all duration-300 hover:shadow-xl hover:ring-2 hover:ring-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 sm:rounded-xl"
       onClick={() => onOpenDetail(item)}
       onMouseEnter={() => setIsActive(true)}
       onMouseLeave={() => setIsActive(false)}
@@ -74,9 +74,9 @@ export default function RecipeCard({ item, onOpenDetail }: RecipeCardProps) {
       onBlur={() => setIsActive(false)}
       aria-label={`View details for ${recipe.title}`}
     >
-      <div className="flex gap-4 p-4">
+      <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-stretch">
         {/* Recipe image - larger and more prominent */}
-        <div className="relative h-40 w-40 flex-shrink-0 overflow-hidden rounded-lg bg-gray-200">
+        <div className="relative h-48 w-full overflow-hidden rounded-2xl bg-gray-200 sm:h-40 sm:w-40 sm:flex-shrink-0 sm:rounded-lg">
           <Image
             src={recipe.imageUrl ?? RECIPE_PLACEHOLDER_IMAGE}
             alt={recipe.title}
@@ -99,7 +99,7 @@ export default function RecipeCard({ item, onOpenDetail }: RecipeCardProps) {
           <div className="flex items-start justify-between">
             <div className="flex-1">
               {/* Meal type badge with improved styling */}
-              <span className="inline-flex items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+              <span className="inline-flex min-h-[32px] items-center rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
                 {mealType}
               </span>
 
@@ -132,7 +132,7 @@ export default function RecipeCard({ item, onOpenDetail }: RecipeCardProps) {
           )}
 
           {/* Stats row */}
-          <div className="mt-3 flex items-center gap-4 text-sm text-gray-600">
+          <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-gray-600 sm:flex sm:flex-wrap sm:items-center sm:gap-4">
             <span className="flex items-center gap-1">
               <span>⏱️</span>
               <span>{recipe.minutes} min</span>
@@ -153,7 +153,7 @@ export default function RecipeCard({ item, onOpenDetail }: RecipeCardProps) {
 
           {/* Hover preview hint */}
           <div
-            className={`mt-2 text-sm text-emerald-600 transition-opacity duration-200 ${
+            className={`mt-3 text-sm text-emerald-600 transition-opacity duration-200 ${
               isActive ? 'opacity-100' : 'opacity-0'
             }`}
           >

--- a/apps/web/src/app/_components/ShoppingList.tsx
+++ b/apps/web/src/app/_components/ShoppingList.tsx
@@ -186,8 +186,8 @@ export default function ShoppingList({ planId, onComparePrices }: ShoppingListPr
             return (
               <Disclosure key={category} defaultOpen={false}>
                 {({ open }: { open: boolean }) => (
-                  <div className="rounded-xl bg-white shadow-sm ring-1 ring-gray-200">
-                    <Disclosure.Button className="flex w-full items-center justify-between gap-3 rounded-xl px-4 py-3 text-left transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:rounded-lg sm:px-5 sm:py-4 min-h-[56px]">
+                  <div className="rounded-2xl bg-white shadow-sm ring-1 ring-gray-200 sm:rounded-xl">
+                    <Disclosure.Button className="flex w-full items-center justify-between gap-3 rounded-2xl px-4 py-4 text-left transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:rounded-lg sm:px-5 sm:py-4 min-h-[60px]">
                       <div className="flex items-center gap-3">
                         <span className="text-2xl">{CATEGORY_EMOJI[category] ?? '📦'}</span>
                         <div>
@@ -206,20 +206,20 @@ export default function ShoppingList({ planId, onComparePrices }: ShoppingListPr
                       />
                     </Disclosure.Button>
 
-                    <Disclosure.Panel className="border-t border-gray-200 p-4">
+                    <Disclosure.Panel className="border-t border-gray-200 p-4 sm:p-5">
                       {/* Category actions */}
                       <div className="mb-4 flex flex-wrap gap-2 sm:gap-3">
                         <button
                           onClick={() => toggleCategory(category, true)}
                           disabled={allChecked}
-                          className="flex-1 min-h-[44px] rounded-lg bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 shadow-sm transition hover:bg-emerald-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:opacity-50 sm:flex-initial sm:px-5"
+                          className="flex-1 min-h-[48px] rounded-lg bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700 shadow-sm transition hover:bg-emerald-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:opacity-50 sm:flex-initial sm:px-5"
                         >
                           Check All
                         </button>
                         <button
                           onClick={() => toggleCategory(category, false)}
                           disabled={categoryCheckedCount === 0}
-                          className="flex-1 min-h-[44px] rounded-lg bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 disabled:opacity-50 sm:flex-initial sm:px-5"
+                          className="flex-1 min-h-[48px] rounded-lg bg-gray-50 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 disabled:opacity-50 sm:flex-initial sm:px-5"
                         >
                           Uncheck All
                         </button>
@@ -234,14 +234,14 @@ export default function ShoppingList({ planId, onComparePrices }: ShoppingListPr
                               <button
                                 type="button"
                                 onClick={() => toggleItem(item.id)}
-                                className={`flex w-full items-center gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-3 py-3 text-left transition hover:border-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:rounded-xl sm:px-4 ${
+                                className={`flex w-full items-center gap-4 rounded-3xl border border-gray-200 bg-gray-50 px-4 py-4 text-left transition hover:border-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:rounded-xl sm:px-5 ${
                                   isChecked ? 'border-emerald-500 bg-emerald-50' : ''
                                 }`}
                                 aria-label={`Toggle ${item.name}`}
                                 aria-pressed={isChecked}
                               >
                                 <span
-                                  className={`flex h-12 w-12 min-h-[48px] min-w-[48px] items-center justify-center rounded-xl border-2 transition sm:h-11 sm:w-11 sm:min-h-[44px] sm:min-w-[44px] ${
+                                  className={`flex h-12 w-12 min-h-[52px] min-w-[52px] items-center justify-center rounded-2xl border-2 transition sm:h-11 sm:w-11 sm:min-h-[48px] sm:min-w-[48px] ${
                                     isChecked
                                       ? 'border-emerald-600 bg-emerald-100 text-emerald-600'
                                       : 'border-gray-300 bg-white text-transparent'

--- a/apps/web/src/app/plan/[id]/page.tsx
+++ b/apps/web/src/app/plan/[id]/page.tsx
@@ -38,13 +38,15 @@ export default async function PlanPage({ params }: PageProps) {
   // Ensure startDate is properly converted to Date if it's a string
   const startDate = plan.startDate instanceof Date ? plan.startDate : new Date(plan.startDate);
 
+  const shoppingListAnchorId = 'plan-shopping-list-section';
+
   return (
     <main className="flex min-h-screen flex-col bg-gradient-to-b from-emerald-50 to-white">
-      <div className="container mx-auto px-4 py-8 sm:px-6 lg:px-8">
+      <div className="container mx-auto px-4 pb-28 pt-6 sm:px-6 sm:pb-16 sm:pt-8 lg:px-8">
         {/* Back Button */}
         <Link
           href="/dashboard"
-          className="mb-6 inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+          className="mb-6 inline-flex w-full min-h-[48px] items-center justify-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 transition hover:bg-gray-50 hover:text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 sm:w-auto sm:justify-start sm:bg-transparent sm:px-0 sm:py-0 sm:text-gray-600 sm:shadow-none sm:ring-0"
         >
           <svg
             className="h-4 w-4"
@@ -76,11 +78,11 @@ export default async function PlanPage({ params }: PageProps) {
         <div className="grid gap-8 lg:grid-cols-3">
           {/* Meal Plan */}
           <div className="lg:col-span-2">
-            <MealPlanView plan={plan} />
+            <MealPlanView plan={plan} shoppingListAnchorId={shoppingListAnchorId} />
           </div>
 
           {/* Shopping List */}
-          <div className="lg:col-span-1">
+          <div id={shoppingListAnchorId} className="scroll-mt-28 rounded-2xl lg:col-span-1">
             <HydrateClient>
               <ShoppingList planId={id} />
             </HydrateClient>


### PR DESCRIPTION
## Summary
- add a floating mobile navigator so users can jump between plan days and the shopping list
- enlarge planner, recipe card, and shopping list touch targets for better thumb-friendly spacing
- tweak plan header layout and anchor positions to prevent FAB overlap and smooth-scroll to sections

## Testing
- pnpm typecheck
- pnpm test

Resolves #87