### PR TITLE
fix: eliminate cleartext password retransmission after signup

### DIFF
--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { db } from '~/server/db';
+import { signIn } from '~/server/auth';
 
 const signUpSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -57,6 +58,13 @@ export async function POST(request: Request) {
           },
         },
       },
+    });
+
+    // Sign in the user to create a session, avoiding need to resend password
+    await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
     });
 
     return NextResponse.json(

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { signIn } from 'next-auth/react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
@@ -58,21 +57,10 @@ function SignUpForm() {
         return;
       }
 
-      // Auto sign-in after successful registration
-      // FIXME return a session token from the server to negate the need to resend cleartext password
-      const result = await signIn('credentials', {
-        email: formData.email,
-        password: formData.password,
-        redirect: false,
-      });
-
-      if (result?.ok) {
-        router.push('/dashboard');
-        router.refresh();
-      } else {
-        // Registration succeeded but sign-in failed - redirect to sign-in page
-        router.push('/auth/signin?message=Account created successfully. Please sign in.');
-      }
+      // User is now signed in via session created on server
+      // No need to resend password in cleartext
+      router.push('/dashboard');
+      router.refresh();
     } catch (err) {
       setError('An unexpected error occurred');
       console.error('Sign up error:', err);


### PR DESCRIPTION
## Summary

Fixes #131 - Critical security issue where password transmitted twice during signup

**Security improvement:** Password now only sent once during signup flow.

## Changes

- ✅ Signup API creates session via `signIn()` after user creation  
- ✅ Client no longer calls `signIn()` with cleartext password
- ✅ Removed unused `next-auth/react` import from signup page

## Impact

- Reduces password exposure window
- Eliminates second network transmission of cleartext password  
- Maintains same UX: auto-signin after signup
- All tests passing

## Testing

- Unit tests pass (signup schema validation)
- Type checking passes
- Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)