### PR TITLE
feat: add password visibility toggle

### DIFF
--- a/apps/web/src/app/auth/_components/PasswordInput.tsx
+++ b/apps/web/src/app/auth/_components/PasswordInput.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+
+interface PasswordInputProps {
+  id: string;
+  name: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  autoComplete?: string;
+  required?: boolean;
+  className?: string;
+  'aria-describedby'?: string;
+}
+
+export default function PasswordInput({
+  id,
+  name,
+  value,
+  onChange,
+  placeholder = 'Enter password',
+  autoComplete,
+  required = false,
+  className = '',
+  'aria-describedby': ariaDescribedby,
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="relative">
+      <input
+        id={id}
+        name={name}
+        type={showPassword ? 'text' : 'password'}
+        autoComplete={autoComplete}
+        required={required}
+        aria-describedby={ariaDescribedby}
+        className={className}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+      <button
+        type="button"
+        onClick={() => setShowPassword(!showPassword)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2 rounded-md"
+        aria-label={showPassword ? 'Hide password' : 'Show password'}
+      >
+        {showPassword ? (
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+          </svg>
+        ) : (
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/auth/reset-password/page.tsx
+++ b/apps/web/src/app/auth/reset-password/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useEffect, useState } from 'react';
 
 import { api } from '~/trpc/react';
 import AuthLayout from '../_components/AuthLayout';
+import PasswordInput from '../_components/PasswordInput';
 
 function ResetPasswordForm() {
   const router = useRouter();
@@ -200,14 +201,13 @@ function ResetPasswordForm() {
               <label htmlFor="password" className="block text-sm font-medium text-gray-700">
                 New password
               </label>
-              <input
+              <PasswordInput
                 id="password"
                 name="password"
-                type="password"
                 autoComplete="new-password"
                 required
                 aria-describedby="password-requirements"
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
                 placeholder="Enter new password (min 8 characters)"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
@@ -221,13 +221,12 @@ function ResetPasswordForm() {
               <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
                 Confirm new password
               </label>
-              <input
+              <PasswordInput
                 id="confirmPassword"
                 name="confirmPassword"
-                type="password"
                 autoComplete="new-password"
                 required
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
                 placeholder="Confirm new password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
 
 import AuthLayout from '../_components/AuthLayout';
+import PasswordInput from '../_components/PasswordInput';
 
 function SignInForm() {
   const router = useRouter();
@@ -118,13 +119,12 @@ function SignInForm() {
                   Forgot password?
                 </Link>
               </div>
-              <input
+              <PasswordInput
                 id="password"
                 name="password"
-                type="password"
                 autoComplete="current-password"
                 required
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
                 placeholder="Enter your password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useState } from 'react';
 
 import AuthLayout from '../_components/AuthLayout';
+import PasswordInput from '../_components/PasswordInput';
 
 function SignUpForm() {
   const router = useRouter();
@@ -182,14 +183,13 @@ function SignUpForm() {
               <label htmlFor="password" className="block text-sm font-medium text-gray-700">
                 Password
               </label>
-              <input
+              <PasswordInput
                 id="password"
                 name="password"
-                type="password"
                 autoComplete="new-password"
                 required
                 aria-describedby="password-hint"
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
                 placeholder="At least 8 characters"
                 value={formData.password}
                 onChange={handleChange}


### PR DESCRIPTION
## Summary
- Implements show/hide toggle for password inputs across all auth pages
- Creates reusable PasswordInput component with eye/eye-slash icon toggle
- 44x44px touch target meets Apple accessibility guidelines
- Applied to signin, signup, and reset-password pages

## Impact
- Reduces password typos, especially on mobile keyboards
- Improves mobile UX with standard pattern users expect
- Enhances accessibility and usability across auth flow

## Testing
- ✅ TypeScript type checking passed
- ✅ All tests passing (139 tests)
- ✅ Linting passed
- ✅ Pre-commit hooks successful

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)