### PR TITLE
feat: enhance CTA hover states (#154)

### DIFF
--- a/apps/web/src/app/_components/CTA.tsx
+++ b/apps/web/src/app/_components/CTA.tsx
@@ -16,7 +16,7 @@ export default function CTA() {
           <div className="mt-8">
             <Link
               href="/auth/signup"
-              className="inline-block rounded-full bg-emerald-600 px-8 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              className="inline-block rounded-full bg-emerald-600 px-8 py-3 text-base font-semibold text-white shadow-sm transition-all duration-150 ease-in-out hover:scale-[1.02] hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
             >
               Get Started
             </Link>

--- a/apps/web/src/app/_components/Hero.tsx
+++ b/apps/web/src/app/_components/Hero.tsx
@@ -34,13 +34,13 @@ export default function Hero() {
           <div className="mt-10 flex items-center justify-center gap-4">
             <Link
               href="/auth/signup"
-              className="rounded-full bg-emerald-600 px-8 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+              className="rounded-full bg-emerald-600 px-8 py-3 text-base font-semibold text-white shadow-sm transition-all duration-150 ease-in-out hover:scale-[1.02] hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
             >
               Get Started
             </Link>
             <Link
               href="/auth/signin"
-              className="rounded-full bg-white/10 px-8 py-3 text-base font-semibold text-white shadow-sm ring-1 ring-white/20 transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              className="rounded-full bg-white/10 px-8 py-3 text-base font-semibold text-white shadow-sm ring-1 ring-white/20 transition-all duration-150 ease-in-out hover:scale-[1.02] hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             >
               Sign In
             </Link>

--- a/apps/web/src/app/_components/Pricing.tsx
+++ b/apps/web/src/app/_components/Pricing.tsx
@@ -81,9 +81,9 @@ export default function Pricing() {
               </ul>
               <Link
                 href={tier.href}
-                className={`mt-8 block w-full rounded-full py-3 text-center text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                className={`mt-8 block w-full rounded-full py-3 text-center text-base font-semibold transition-all duration-150 ease-in-out hover:scale-[1.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
                   tier.highlighted
-                    ? 'bg-emerald-600 text-white hover:bg-emerald-700 focus-visible:outline-emerald-600'
+                    ? 'bg-emerald-600 text-white hover:bg-emerald-500 focus-visible:outline-emerald-600'
                     : 'bg-white text-emerald-700 ring-1 ring-emerald-600 hover:bg-emerald-50 focus-visible:outline-emerald-600'
                 }`}
               >


### PR DESCRIPTION
## Summary
- Add subtle scale transform (1.02) on hover
- Use lighter emerald-500 on hover (vs darker emerald-700)
- Smooth 150ms transition-all ease-in-out
- Applied to Hero CTAs, CTA section, and Pricing buttons

Follows Apple design standards for interactive element feedback.

## Test plan
- [x] Hooks pass
- [x] All tests pass
- [ ] Visual: Hover over "Get Started" and "Sign In" buttons on landing page
- [ ] Visual: Hover over "Go Premium" button in pricing section
- [ ] Verify scale animation is smooth and subtle

🤖 Generated with [Claude Code](https://claude.com/claude-code)