### PR TITLE
Right-size wizard emojis on mobile

### DIFF
--- a/apps/web/src/app/_components/MealPlanWizard.tsx
+++ b/apps/web/src/app/_components/MealPlanWizard.tsx
@@ -119,7 +119,7 @@ export default function MealPlanWizard({
                 className="flex items-center gap-2 text-sm font-semibold text-gray-900"
               >
                 <span>How many people?</span>
-                <span className="text-xl" role="img" aria-label="people">
+                <span className="text-lg leading-none sm:text-xl" role="img" aria-label="people">
                   👥
                 </span>
               </label>
@@ -144,7 +144,7 @@ export default function MealPlanWizard({
                 className="flex items-center gap-2 text-sm font-semibold text-gray-900"
               >
                 <span>How many meals per day?</span>
-                <span className="text-xl" role="img" aria-label="meals">
+                <span className="text-lg leading-none sm:text-xl" role="img" aria-label="meals">
                   🍽️
                 </span>
               </label>
@@ -167,7 +167,7 @@ export default function MealPlanWizard({
                 className="flex items-center gap-2 text-sm font-semibold text-gray-900"
               >
                 <span>How many days to plan?</span>
-                <span className="text-xl" role="img" aria-label="calendar">
+                <span className="text-lg leading-none sm:text-xl" role="img" aria-label="calendar">
                   📅
                 </span>
               </label>
@@ -197,7 +197,7 @@ export default function MealPlanWizard({
             <div className="space-y-3">
               <span className="flex items-center gap-2 text-sm font-semibold text-gray-900">
                 <span>Dietary preferences</span>
-                <span className="text-xl" role="img" aria-label="diet">
+                <span className="text-lg leading-none sm:text-xl" role="img" aria-label="diet">
                   🥗
                 </span>
               </span>
@@ -242,7 +242,7 @@ export default function MealPlanWizard({
                 className="flex items-center gap-2 text-sm font-semibold text-gray-900"
               >
                 <span>Foods to avoid (optional)</span>
-                <span className="text-xl" role="img" aria-label="avoid">
+                <span className="text-lg leading-none sm:text-xl" role="img" aria-label="avoid">
                   🚫
                 </span>
               </label>


### PR DESCRIPTION
## Summary\n- shrink wizard field emojis on small screens so labels stay the focus\n- keep larger sizing on sm+ layouts to preserve the playful vibe\n\nFixes #157\n\n## Testing\n- AUTH_SECRET=placeholder DATABASE_URL=postgresql://placeholder pnpm lint\n- pnpm test\n- pnpm --filter @meal-planner-demo/web typecheck