### PR TITLE
feat: add mock premium signup paywall

### DIFF
--- a/apps/web/src/app/api/auth/signup/schema.ts
+++ b/apps/web/src/app/api/auth/signup/schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const signUpSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .max(128, 'Password must be at most 128 characters')
+    .regex(/[A-Z]/, 'Password must include at least one uppercase letter')
+    .regex(/[0-9]/, 'Password must include at least one number'),
+  name: z.string().trim().min(1, 'Name is required'),
+  tier: z.enum(['basic', 'premium']).default('basic'),
+});

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -12,6 +12,8 @@ function SignUpForm() {
   const searchParams = useSearchParams();
   const tier = searchParams.get('tier');
   const isPremium = tier === 'premium';
+  const [currentStep, setCurrentStep] = useState<'details' | 'payment'>('details');
+  const isPaymentStep = isPremium && currentStep === 'payment';
 
   const [formData, setFormData] = useState({
     name: '',
@@ -21,11 +23,48 @@ function SignUpForm() {
   const [error, setError] = useState('');
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
+  const [paymentError, setPaymentError] = useState('');
+  const [paymentData, setPaymentData] = useState({
+    cardName: '',
+    cardNumber: '',
+    expiry: '',
+    cvc: '',
+    confirmMock: false,
+  });
+
+  const validatePaymentStep = () => {
+    if (
+      !paymentData.cardName ||
+      !paymentData.cardNumber ||
+      !paymentData.expiry ||
+      !paymentData.cvc
+    ) {
+      setPaymentError('Please add mock card details to continue.');
+      return false;
+    }
+    if (!paymentData.confirmMock) {
+      setPaymentError('Please confirm you understand this is a mock payment.');
+      return false;
+    }
+    return true;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isPremium && currentStep === 'details') {
+      setCurrentStep('payment');
+      return;
+    }
+
     setError('');
     setValidationErrors({});
+    setPaymentError('');
+
+    if (isPaymentStep && !validatePaymentStep()) {
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -34,7 +73,10 @@ function SignUpForm() {
       const response = await fetch(`${basePath}/api/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({
+          ...formData,
+          tier: isPremium ? 'premium' : 'basic',
+        }),
       });
 
       const data = (await response.json()) as {
@@ -85,6 +127,25 @@ function SignUpForm() {
     }
   };
 
+  const handlePaymentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type, checked } = e.target;
+    setPaymentData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+    if (paymentError) {
+      setPaymentError('');
+    }
+  };
+
+  const primaryButtonLabel = loading
+    ? 'Creating account...'
+    : isPaymentStep
+      ? 'Complete payment & create account'
+      : isPremium
+        ? 'Continue to payment'
+        : 'Create account';
+
   return (
     <>
       <Link
@@ -120,11 +181,20 @@ function SignUpForm() {
       >
         <form className="space-y-6" onSubmit={handleSubmit}>
           {isPremium && (
-            <div className="rounded-md bg-emerald-50 p-4 border border-emerald-200">
-              <p className="text-sm text-emerald-800 font-medium">
-                Premium Tier: €4.99/month — Best value supermarket finder, advanced customisation,
-                and more!
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4">
+              <p className="text-sm font-semibold text-emerald-900">
+                {isPaymentStep ? 'Step 2 of 2 — Mock payment' : 'Step 1 of 2 — Account details'}
               </p>
+              <p className="mt-1 text-sm text-emerald-800">
+                Premium Tier: €4.99/month • Advanced plan settings, longer plans, and supermarket
+                comparisons.
+              </p>
+              {isPaymentStep && (
+                <p className="mt-2 text-xs text-emerald-700">
+                  This is a fake payment screen — no real charges happen today. It simply unlocks
+                  premium permissions for testing.
+                </p>
+              )}
             </div>
           )}
 
@@ -134,76 +204,189 @@ function SignUpForm() {
             </div>
           )}
 
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="name" className="block text-sm font-medium text-gray-700">
-                Name
-              </label>
-              <input
-                id="name"
-                name="name"
-                type="text"
-                autoComplete="name"
-                required
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
-                placeholder="Your name"
-                value={formData.name}
-                onChange={handleChange}
-              />
-              {validationErrors.name && (
-                <p className="mt-1 text-sm text-red-600" role="alert">
-                  {validationErrors.name}
+          {isPaymentStep ? (
+            <div className="space-y-6 rounded-xl border border-emerald-100 bg-white/80 p-5 shadow-sm">
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">Mock payment details</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                  Enter pretend card info so we can show the final confirmation screen. These values
+                  are not saved and no charge is made.
                 </p>
-              )}
-            </div>
+              </div>
 
-            <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                Email address
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
-                placeholder="you@example.com"
-                value={formData.email}
-                onChange={handleChange}
-              />
-              {validationErrors.email && (
-                <p className="mt-1 text-sm text-red-600" role="alert">
-                  {validationErrors.email}
-                </p>
-              )}
-            </div>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="cardName" className="block text-sm font-medium text-gray-700">
+                    Name on card
+                  </label>
+                  <input
+                    id="cardName"
+                    name="cardName"
+                    type="text"
+                    autoComplete="cc-name"
+                    className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                    placeholder="Jamie Example"
+                    value={paymentData.cardName}
+                    onChange={handlePaymentChange}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="cardNumber" className="block text-sm font-medium text-gray-700">
+                    Card number
+                  </label>
+                  <input
+                    id="cardNumber"
+                    name="cardNumber"
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="cc-number"
+                    className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                    placeholder="4242 4242 4242 4242"
+                    value={paymentData.cardNumber}
+                    onChange={handlePaymentChange}
+                  />
+                </div>
 
-            <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-                Password
-              </label>
-              <PasswordInput
-                id="password"
-                name="password"
-                autoComplete="new-password"
-                required
-                aria-describedby="password-hint"
-                className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
-                placeholder="At least 8 characters"
-                value={formData.password}
-                onChange={handleChange}
-              />
-              {validationErrors.password && (
-                <p className="mt-1 text-sm text-red-600" role="alert">
-                  {validationErrors.password}
-                </p>
-              )}
-              <p id="password-hint" className="mt-1 text-xs text-gray-500">
-                Must be at least 8 characters with one uppercase letter and one number
-              </p>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label htmlFor="expiry" className="block text-sm font-medium text-gray-700">
+                      Expiry
+                    </label>
+                    <input
+                      id="expiry"
+                      name="expiry"
+                      type="text"
+                      autoComplete="cc-exp"
+                      className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                      placeholder="04 / 28"
+                      value={paymentData.expiry}
+                      onChange={handlePaymentChange}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="cvc" className="block text-sm font-medium text-gray-700">
+                      CVC
+                    </label>
+                    <input
+                      id="cvc"
+                      name="cvc"
+                      type="text"
+                      inputMode="numeric"
+                      autoComplete="cc-csc"
+                      className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                      placeholder="123"
+                      value={paymentData.cvc}
+                      onChange={handlePaymentChange}
+                    />
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-900">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-semibold">MealMind Premium</p>
+                      <p className="text-emerald-800">€4.99/month — charged later</p>
+                    </div>
+                    <p className="text-lg font-semibold text-emerald-700">€0.00 today</p>
+                  </div>
+                  <ul className="mt-3 list-disc space-y-1 pl-5 text-emerald-800">
+                    <li>Generate up to 7-day plans</li>
+                    <li>Advanced dietary filters</li>
+                    <li>Premium shopping list exports</li>
+                  </ul>
+                </div>
+
+                <label className="inline-flex items-start gap-3 text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    name="confirmMock"
+                    checked={paymentData.confirmMock}
+                    onChange={handlePaymentChange}
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-600"
+                  />
+                  <span>
+                    I understand this is a mock payment screen and grants premium access instantly.
+                  </span>
+                </label>
+                {paymentError && (
+                  <p className="text-sm text-red-600" role="alert">
+                    {paymentError}
+                  </p>
+                )}
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  autoComplete="name"
+                  required
+                  className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                  placeholder="Your name"
+                  value={formData.name}
+                  onChange={handleChange}
+                />
+                {validationErrors.name && (
+                  <p className="mt-1 text-sm text-red-600" role="alert">
+                    {validationErrors.name}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                  Email address
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                  placeholder="you@example.com"
+                  value={formData.email}
+                  onChange={handleChange}
+                />
+                {validationErrors.email && (
+                  <p className="mt-1 text-sm text-red-600" role="alert">
+                    {validationErrors.email}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                  Password
+                </label>
+                <PasswordInput
+                  id="password"
+                  name="password"
+                  autoComplete="new-password"
+                  required
+                  aria-describedby="password-hint"
+                  className="mt-1 block w-full rounded-lg border border-gray-200 px-4 py-3 pr-12 text-base text-gray-900 shadow-sm transition placeholder:text-gray-400 focus:border-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+                  placeholder="At least 8 characters"
+                  value={formData.password}
+                  onChange={handleChange}
+                />
+                {validationErrors.password && (
+                  <p className="mt-1 text-sm text-red-600" role="alert">
+                    {validationErrors.password}
+                  </p>
+                )}
+                <p id="password-hint" className="mt-1 text-xs text-gray-500">
+                  Must be at least 8 characters with one uppercase letter and one number
+                </p>
+              </div>
+            </div>
+          )}
 
           <div>
             <button
@@ -211,8 +394,20 @@ function SignUpForm() {
               disabled={loading}
               className="flex w-full min-h-[48px] items-center justify-center rounded-lg bg-emerald-600 px-4 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 disabled:cursor-not-allowed disabled:bg-emerald-300"
             >
-              {loading ? 'Creating account...' : 'Create account'}
+              {primaryButtonLabel}
             </button>
+            {isPaymentStep && (
+              <button
+                type="button"
+                className="mt-3 w-full min-h-[44px] rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+                onClick={() => {
+                  setCurrentStep('details');
+                  setPaymentError('');
+                }}
+              >
+                Back to details
+              </button>
+            )}
           </div>
         </form>
       </AuthLayout>


### PR DESCRIPTION
## Summary
- add two-step premium signup flow with a mock payment gate so testers experience the paywall
- ensure signup API accepts a tier flag, persisting premium role immediately
- consolidate signup schema + tighten tests covering tier validation

## Testing
- pnpm --filter @meal-planner-demo/web exec vitest run src/app/api/auth/signup/route.test.ts
- pnpm test

Closes #169