### PR TITLE
Fix: Navbar displays correct user email (#188)

### DIFF
--- a/apps/web/src/server/auth/config.ts
+++ b/apps/web/src/server/auth/config.ts
@@ -171,9 +171,12 @@ export const authConfig = {
   },
   callbacks: {
     jwt: async ({ token, user }) => {
-      // On first sign-in, ensure we attach the user id and role
+      // On first sign-in, ensure we attach the user id, email, and role
       if (user?.id) {
         token.id = user.id;
+      }
+      if (user?.email) {
+        token.email = user.email;
       }
       // If user object has role (from authorize), use it directly
       if (user && 'role' in user) {
@@ -197,6 +200,7 @@ export const authConfig = {
       user: {
         ...session.user,
         id: typeof token.id === 'string' ? token.id : session.user.id,
+        email: typeof token.email === 'string' ? token.email : session.user.email,
         role: typeof token.role === 'string' ? token.role : undefined,
       },
     }),


### PR DESCRIPTION
## Summary
- Fixes navbar showing hardcoded test email to all users
- Added explicit email handling in JWT callback
- Pass email from token to session in session callback

## Root Cause
With JWT session strategy, email wasn't explicitly stored in token or passed to session, causing session.user.email to be undefined/incorrect.

## Changes
**apps/web/src/server/auth/config.ts:**- JWT callback: Store user.email in token on sign-in- Session callback: Pass token.email to session.user.email

## Testing
Manual testing required:
1. Sign up with new email
2. Verify navbar shows correct email
3. Test both free/premium tiers

## Fixes
Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)