### PR TITLE
Fix: Recipe swap creates duplicate recipes instead of replacing

### DIFF
--- a/apps/web/src/server/api/routers/plan.ts
+++ b/apps/web/src/server/api/routers/plan.ts
@@ -247,14 +247,17 @@ export const planRouter = createTRPCRouter({
       // Find alternative recipes that match:
       // 1. Same meal type
       // 2. Dietary preferences
-      // 3. Not the current recipe
+      // 3. Not already in the plan
       // 4. Not disliked
       const currentRecipeId = itemToSwap.recipeId;
       const mealType = itemToSwap.mealType;
 
+      // Get all recipe IDs currently in the plan to avoid duplicates
+      const usedRecipeIds = plan.items.map((item) => item.recipeId);
+
       const alternativeRecipes = await ctx.db.recipe.findMany({
         where: {
-          id: { not: currentRecipeId },
+          id: { notIn: usedRecipeIds },
           mealTypes: { has: mealType },
           ...(isVegetarian && { isVegetarian: true }),
           ...(isDairyFree && { isDairyFree: true }),


### PR DESCRIPTION
## Summary
- Modified recipe swap mutation to exclude ALL recipes in plan, not just swapped one
- Prevents selecting recipe already used in another day
- Fixes duplicate recipes appearing across multiple days

## Changes
- Extract all recipe IDs from meal plan items
- Use `notIn` filter instead of `not` to exclude all used recipes
- Ensures each day has unique recipes after swap

## Testing
- All existing tests pass
- Recipe swap now guarantees no duplicates

Fixes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)