### PR TITLE
Fix Hero image mock to remove DOM warnings

### DIFF
--- a/apps/web/src/app/_components/Hero.test.tsx
+++ b/apps/web/src/app/_components/Hero.test.tsx
@@ -3,6 +3,33 @@ import { describe, it, expect, vi } from 'vitest';
 import type { ImageProps } from 'next/image';
 import Hero from './Hero';
 
+const resolveMockSrc = (source: ImageProps['src']) => {
+  if (typeof source === 'string') return source;
+
+  if (
+    typeof source === 'object' &&
+    source !== null &&
+    'src' in source &&
+    typeof source.src === 'string'
+  ) {
+    return source.src;
+  }
+
+  if (
+    typeof source === 'object' &&
+    source !== null &&
+    'default' in source &&
+    source.default &&
+    typeof source.default === 'object' &&
+    'src' in source.default &&
+    typeof source.default.src === 'string'
+  ) {
+    return source.default.src;
+  }
+
+  return '';
+};
+
 // Mock next/image while stripping non-standard DOM props
 vi.mock('next/image', () => ({
   default: ({ alt, src, className, ...props }: ImageProps) => {
@@ -16,12 +43,7 @@ vi.mock('next/image', () => ({
 
     return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img
-        alt={alt}
-        src={typeof src === 'string' ? src : (src?.src ?? '')}
-        className={className}
-        {...imgProps}
-      />
+      <img alt={alt} src={resolveMockSrc(src)} className={className} {...imgProps} />
     );
   },
 }));


### PR DESCRIPTION
## Summary
- update the Hero test's next/image mock to strip non-DOM props
- preserve required attributes while avoiding noisy warnings during rendering

## Testing
- pnpm test -- src/app/_components/Hero.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692739445b608333ac4c7e56eefbd03d)