### PR TITLE
Add VS Code workspace settings for linting and Prisma support

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "prisma.prisma",
+    "bradlc.vscode-tailwindcss"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "eslint.workingDirectories": [
+    {
+      "directory": "apps/web",
+      "changeProcessCWD": true
+    }
+  ],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "files.associations": {
+    "*.prisma": "prisma"
+  }
+}


### PR DESCRIPTION
## Summary
- add VS Code workspace settings for formatting on save and monorepo-aware ESLint
- configure the workspace TypeScript SDK prompt and Prisma file association
- recommend common linting, formatting, Prisma, and Tailwind CSS extensions for contributors

## Testing
- not run (config-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692742b3c1108333a8383fb12b320496)