### PR TITLE
Fix lint issues blocking merge

### DIFF
--- a/apps/web/src/app/_components/EmptyState.tsx
+++ b/apps/web/src/app/_components/EmptyState.tsx
@@ -56,7 +56,7 @@ export default function EmptyState({
       <p className="mb-6 max-w-md text-base leading-relaxed text-gray-600">{description}</p>
 
       {/* Actions */}
-      {(actionLabel || secondaryAction) && (
+      {(actionLabel ?? secondaryAction) && (
         <div className="flex flex-col gap-3 sm:flex-row">
           {actionLabel && actionHref && (
             <Link

--- a/apps/web/src/app/_components/Hero.test.tsx
+++ b/apps/web/src/app/_components/Hero.test.tsx
@@ -32,14 +32,14 @@ const resolveMockSrc = (source: ImageProps['src']) => {
 
 // Mock next/image while stripping non-standard DOM props
 vi.mock('next/image', () => ({
-  default: ({ alt, src, className, ...props }: ImageProps) => {
-    const {
-      fill: _fill,
-      priority: _priority,
-      placeholder: _placeholder,
-      blurDataURL: _blurDataURL,
-      ...imgProps
-    } = props;
+  default: ({ alt, src, className, ...imageProps }: ImageProps) => {
+    const { fill, priority, placeholder, blurDataURL, ...imgProps } = imageProps;
+
+    // Explicitly acknowledge ignored Next.js-only props to satisfy ESLint
+    void fill;
+    void priority;
+    void placeholder;
+    void blurDataURL;
 
     return (
       // eslint-disable-next-line @next/next/no-img-element

--- a/apps/web/src/server/api/routers/plan.test.ts
+++ b/apps/web/src/server/api/routers/plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { type TRPCError } from '@trpc/server';
+import type * as PlanGeneratorModule from '../../services/planGenerator';
 
 import { createMockContext, mockPrismaClient } from '~/test/mocks';
 
@@ -14,7 +15,7 @@ vi.mock('~/server/db', () => ({
 const mockGeneratePlan = vi.fn();
 const mockBuildAndStoreForPlan = vi.fn();
 
-const planModulePromise = vi.importActual<typeof import('../../services/planGenerator')>(
+const planModulePromise = vi.importActual<typeof PlanGeneratorModule>(
   '../../services/planGenerator'
 );
 

--- a/apps/web/src/server/api/routers/plan.ts
+++ b/apps/web/src/server/api/routers/plan.ts
@@ -249,7 +249,6 @@ export const planRouter = createTRPCRouter({
       // 2. Dietary preferences
       // 3. Not already in the plan
       // 4. Not disliked
-      const currentRecipeId = itemToSwap.recipeId;
       const mealType = itemToSwap.mealType;
 
       // Get all recipe IDs currently in the plan to avoid duplicates


### PR DESCRIPTION
## Summary
- use nullish coalescing in EmptyState actions to satisfy lint expectations
- update Hero image mock to ignore Next.js-only props without unused variable warnings
- adjust plan router test typing and remove unused variables to clear remaining lint feedback

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69277674611c8333af5a96d8ead81b8a)