### PR TITLE
Fix test failures by skipping env validation in test environment

### DIFF
--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,3 +1,6 @@
+// Skip env validation in tests to avoid server-side env var access errors
+process.env.SKIP_ENV_VALIDATION = 'true';
+
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     environment: 'happy-dom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    env: {
+      SKIP_ENV_VALIDATION: 'true',
+    },
     pool: 'threads',
     maxWorkers: 1,
     coverage: {


### PR DESCRIPTION
## Summary
- Fixed test failures in `src/server/api/root.test.ts` by setting `SKIP_ENV_VALIDATION=true`
- The tests were failing because the happy-dom test environment was detected as "client-side" by `@t3-oss/env-nextjs`, blocking access to server-side environment variables

## Changes
- Added `SKIP_ENV_VALIDATION=true` to vitest.config.ts `env` option
- Added `process.env.SKIP_ENV_VALIDATION = 'true'` to test setup file for redundancy

## Test plan
- [x] All 281 tests pass locally
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)