### PR TITLE
Add .prettierignore to exclude pnpm-lock.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Lock files are auto-generated and should not be formatted
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- Added `.prettierignore` to exclude `pnpm-lock.yaml` from Prettier formatting
- Lock files are auto-generated and should not be formatted

## Test plan
- [ ] CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)