### PR TITLE
docs: add admin user credentials and update image pipeline model details

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,7 +110,7 @@ pnpm --filter @meal-planner-demo/types <command>
 - All schema changes via Prisma migrations
 - Include rollback scripts for migrations
 - Database can be started with Docker Compose or the `./start-database.sh` script
-- Seed data includes test users (premium@example.com, basic@example.com) and sample recipes
+- Seed data includes test users (admin@example.com, premium@example.com, basic@example.com) and sample recipes
 
 ### Quality Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ These instructions apply to the entire repository. Keep documentation DRY by lea
 - Next.js 15 (App Router) with React Server Components where practical
 - Strict TypeScript; avoid `any`
 - tRPC v11 + React Query 5
-- Prisma 6 on PostgreSQL; seed users `premium@example.com` / `basic@example.com` with password `P@ssw0rd!`
+- Prisma 6 on PostgreSQL; seed users `admin@example.com` / `premium@example.com` / `basic@example.com` with password `P@ssw0rd!`
 - Tailwind CSS 4, Prettier + ESLint formatting and linting
 - Monorepo managed by pnpm workspaces (root scripts delegate to `apps/web`)
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ cd apps/web && pnpm prisma db seed
 
 This will create:
 
+- **Admin user**: `admin@example.com` / `P@ssw0rd!` (access to image generation pipeline)
 - **Premium user**: `premium@example.com` / `P@ssw0rd!`
 - **Basic user**: `basic@example.com` / `P@ssw0rd!`
 - 22 diverse sample recipes with ingredients (quick meals, batch-prep options, and one-pot dinners)

--- a/SEEDING_DEPLOYMENT.md
+++ b/SEEDING_DEPLOYMENT.md
@@ -82,7 +82,8 @@ The seed script populates:
 
 - **12 recipes** (various cuisines, dietary preferences)
 - **29 ingredients** (categorized: protein, vegetables, dairy, grains, pantry)
-- **2 test users:**
+- **3 test users:**
+  - `admin@example.com` / `P@ssw0rd!` (admin access to image generation)
   - `premium@example.com` / `P@ssw0rd!` (7-day meal plans)
   - `basic@example.com` / `P@ssw0rd!` (3-day meal plans)
 - **Price baselines** for shopping list cost estimation

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -7,7 +7,7 @@ This document centralizes the current state of the monorepo so other docs (READM
 - Next.js 15 (App Router) with React Server Components where practical
 - TypeScript-first with strict settings; avoid `any`
 - tRPC v11 + React Query 5 for client/server contracts
-- Prisma 6 with PostgreSQL; seed users include `premium@example.com` and `basic@example.com` (password: `P@ssw0rd!`)
+- Prisma 6 with PostgreSQL; seed users include `admin@example.com`, `premium@example.com`, and `basic@example.com` (password: `P@ssw0rd!`)
 - Tailwind CSS 4 for styling, Prettier + ESLint for formatting and linting
 
 ## Monorepo Layout
@@ -20,7 +20,7 @@ This document centralizes the current state of the monorepo so other docs (READM
 
 ## Environment & Data
 
-1. Copy environment files: `cp .env.example .env && cp .env apps/web/.env` and fill required secrets (e.g., `AUTH_SECRET`). Set `GEMINI_API_KEY` if you want to use the admin-only Gemini 2.5 Flash Image pipeline; otherwise that UI stays disabled.
+1. Copy environment files: `cp .env.example .env && cp .env apps/web/.env` and fill required secrets (e.g., `AUTH_SECRET`). Set `GEMINI_API_KEY` if you want to use the admin-only Gemini image pipeline; otherwise that UI stays disabled.
 2. Start a database:
    - Postgres only: `docker compose up -d postgres` or `./start-database.sh`
    - Full local stack (web + Postgres + Mailpit): `pnpm docker:dev` / tear down with `pnpm docker:dev:down`
@@ -48,7 +48,7 @@ This document centralizes the current state of the monorepo so other docs (READM
 
 ## Admin Tools
 
-- Gemini image pipeline: `/dashboard/admin/images` (requires admin role). Uses Google's Gemini 2.5 Flash Image endpoint through env-configured credentials. Generated files are written to `apps/web/public/generated-images/` for now; swap in blob/object storage later.
+- Gemini image pipeline: `/dashboard/admin/images` (requires admin role). Supports two model options: "Nano Banana Pro" (`gemini-3-pro-image-preview`) and "Nano Banana" (`gemini-2.5-flash-image`). Configure via `GEMINI_API_KEY` env variable. Generated files are written to `apps/web/public/generated-images/` for now; swap in blob/object storage later.
 
 ## Agent & Contributor Notes
 


### PR DESCRIPTION
## Summary

- Add `admin@example.com` to seed user documentation across all files for consistency
- Document both Gemini model options available in the image generation pipeline:
  - "Nano Banana Pro" (`gemini-3-pro-image-preview`)
  - "Nano Banana" (`gemini-2.5-flash-image`)

## Changes

Updates documentation in:
- `docs/REFERENCE.md` - Main reference doc with full model details
- `README.md` - Getting started guide
- `AGENTS.md` - AI agent instructions
- `SEEDING_DEPLOYMENT.md` - Deployment seeding docs
- `.github/copilot-instructions.md` - GitHub Copilot context

## Test plan

- [x] Verified admin user exists in seed.ts and works for login
- [x] Verified image generation UI matches documented model names
- [x] Confirmed all seed user references are now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)